### PR TITLE
chore: rename module to include it vanity list

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -12,8 +12,8 @@ import (
 	"go.octolab.org/toolkit/cli/cobra"
 	"go.octolab.org/unsafe"
 
-	"go.octolab.org/sparkle/internal/command"
-	"go.octolab.org/sparkle/internal/config"
+	"go.octolab.org/ecosystem/sparkle/internal/command"
+	"go.octolab.org/ecosystem/sparkle/internal/config"
 )
 
 const unknown = "unknown"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,8 +12,8 @@ import (
 	"go.octolab.org/toolkit/cli/cobra"
 	"go.octolab.org/unsafe"
 
-	"go.octolab.org/sparkle/internal/command"
-	"go.octolab.org/sparkle/internal/config"
+	"go.octolab.org/ecosystem/sparkle/internal/command"
+	"go.octolab.org/ecosystem/sparkle/internal/config"
 )
 
 const unknown = "unknown"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.octolab.org/sparkle
+module go.octolab.org/ecosystem/sparkle
 
 go 1.20
 

--- a/internal/command/client_test.go
+++ b/internal/command/client_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "go.octolab.org/sparkle/internal/command"
+	. "go.octolab.org/ecosystem/sparkle/internal/command"
 )
 
 func TestNewClient(t *testing.T) {

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	service "go.octolab.org/sparkle"
-	"go.octolab.org/sparkle/internal/config"
+	service "go.octolab.org/ecosystem/sparkle"
+	"go.octolab.org/ecosystem/sparkle/internal/config"
 )
 
 // NewServer returns the new server command.

--- a/internal/command/server_test.go
+++ b/internal/command/server_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "go.octolab.org/sparkle/internal/command"
+	. "go.octolab.org/ecosystem/sparkle/internal/command"
 )
 
 func TestNewServer(t *testing.T) {

--- a/tests/sandbox/telegram/main.go
+++ b/tests/sandbox/telegram/main.go
@@ -1,3 +1,5 @@
+//go:build telegram
+
 package main
 
 import (
@@ -11,11 +13,10 @@ import (
 	"text/template"
 
 	"github.com/google/uuid"
+	tdlib "github.com/zelenin/go-tdlib/client"
 	"go.octolab.org/safe"
 	"go.octolab.org/unsafe"
 	"gopkg.in/yaml.v3"
-
-	tdlib "github.com/zelenin/go-tdlib/client"
 )
 
 var app = struct {


### PR DESCRIPTION
**Motivation:** all service-type projects have `/ecosystem/` namespace.